### PR TITLE
fix: exit fullscreen model dup error

### DIFF
--- a/.changeset/chatty-frogs-press.md
+++ b/.changeset/chatty-frogs-press.md
@@ -1,0 +1,5 @@
+---
+"ng-monaco-editor": patch
+---
+
+fix: exit fullscreen model dup error

--- a/src/monaco-common-editor.component.ts
+++ b/src/monaco-common-editor.component.ts
@@ -208,11 +208,10 @@ export abstract class MonacoCommonEditorComponent
 
   createModel(value: string, uri?: string): editor.ITextModel {
     const { monaco } = this.monacoProvider;
-    return monaco.editor.createModel(
-      value,
-      this.options.language,
-      uri ? monaco.Uri.parse(uri) : undefined,
-    );
+    const modelUri = uri ? monaco.Uri.parse(uri) : undefined;
+    const model = modelUri && monaco.editor.getModel(modelUri);
+    model?.dispose();
+    return monaco.editor.createModel(value, this.options.language, modelUri);
   }
 
   private async resetEditor() {


### PR DESCRIPTION
在 `aui-code-editor` 使用中，全屏查看后退出全屏，使用 `modelUri` 的实例会因为 model 已存在而创建 model 失败，导致编辑器无法正常使用 
在对话框动画效果实现之前应该比较难触发

直接返回已有的 model ，里面的 value 会丢，手动 setValue 似乎也不行；怀疑是 model 的 editor 实例也就是对话框里的那个销毁了，model 返回给新实例后也被回收了，才有的退出全屏后有内容然后又没了
所以每次创建新的，都会尝试 dispose 已有的


https://github.com/alauda/ng-monaco-editor/assets/24679861/4cde5e60-9944-4efd-99f2-c602e057665a



